### PR TITLE
Ensure box Durations are valid.

### DIFF
--- a/internal/server/boxes.go
+++ b/internal/server/boxes.go
@@ -197,6 +197,14 @@ func addBox(box api.Box) (id string, err error) {
 
 	box.LastUpdate = t
 
+	if box.MaxTBU != nil && box.MaxTBU.Duration() == 0 {
+		box.MaxTBU = nil
+	}
+
+	if box.ExpireAfter != nil && box.ExpireAfter.Duration() == 0 {
+		box.ExpireAfter = nil
+	}
+
 	// Add to store (thread-safe)
 	if err := boxStore.Add(box); err != nil {
 		return "", err


### PR DESCRIPTION
Often people supply a 0 value to MaxTBU or ExpireAfter fields when creating a box causing them to be immediately deleted or marked out of date. As there is no scenario where this would be sensible I'm setting them to nil instead.  Setting an update to an empty value can be correct if you want to reset the Duration but that's already handled correctly.